### PR TITLE
Fix ScrollMethod variants

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -93,7 +93,8 @@ pub enum ClickMethod {
 #[derive(Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ScrollMethod {
-    TwoFingerEdge,
+    TwoFinger,
+    Edge,
     OnButtonDown,
     None,
 }


### PR DESCRIPTION
`two_finger` and `edge` are separate variants (see [`man 5 sway-input`](https://github.com/swaywm/sway/blob/master/sway/sway-input.5.scd#L164)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaycefayne/swayipc-rs/1)
<!-- Reviewable:end -->
