### PR TITLE
Make EventType Copy, Eq, and Hash.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -4,7 +4,7 @@ use serde_derive::Serialize;
 use serde_json::from_slice;
 use std::convert::TryFrom;
 
-#[derive(Debug, Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EventType {
     Workspace,


### PR DESCRIPTION
This makes associating handlers with event types easier for clients.