### PR TITLE
handle `null` for Workspace::representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ keywords = ["sway", "swaywm", "swayipc","ipc", "async"]
 readme = "README.md"
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 failure = "0.1"
 futures-core = { version = "0.3", optional = true }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use crate::reply::Event;
 use crate::{bail, Error};
-use serde_derive::Serialize;
+use serde::Serialize;
 use serde_json::from_slice;
 use std::convert::TryFrom;
 

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -1,4 +1,4 @@
-use serde_derive::Deserialize;
+use serde::{Deserializer, Deserialize};
 
 #[derive(Debug, Deserialize)]
 pub struct CommandOutcome {
@@ -14,11 +14,19 @@ pub struct Workspace {
     pub visible: bool,
     pub focused: bool,
     pub urgent: bool,
+    #[serde(deserialize_with = "default_on_null")]
     pub representation: String,
     pub orientation: String,
     pub rect: Rect,
     pub output: String,
     pub focus: Vec<u32>,
+}
+
+fn default_on_null<'de, D, T: Default + Deserialize<'de>>(deserializer: D) -> Result<T, D::Error>
+    where D: Deserializer<'de>
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
It seems that on newly created, empty workspaces the representation can be `null`, with this change the representation gets deserialized to an empty string in that case.
Another option would be to switch to Option<String>, which I haven't done here to preserve backwards compatibility.

Additionally this changes from requiring `serde_derive` directly towards using the `derive` feature of `serde`, because the compiler didn't like `use`ing a trait and macro of the same name.