### PR TITLE
Allow fallback to I3SOCK for compat with i3

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -2,6 +2,11 @@ use crate::{bail, Fallible};
 use std::{env, process};
 
 pub fn get_path() -> Fallible<String> {
+    // Check I3SOCK first to allow compatibility with i3.
+    // sway sets I3SOCK to point to SWAYSOCK, so tihs also works for sway.
+    if let Ok(sockpath) = env::var("I3SOCK") {
+        return Ok(sockpath);
+    }
     if let Ok(sockpath) = env::var("SWAYSOCK") {
         return Ok(sockpath);
     }


### PR DESCRIPTION
This allows `swayipc-rs` to be used in programs that support both i3 and sway,
without having to add two separate dependencies such as `swayipc-rs` for sway
and `i3ipc-rs` for i3.

I plan on using this crate over i3ipc-rs in `i3status-rust` if this is merged. Have tested in both sway and i3.