### PR TITLE
i3 compat: add fallback to --get-socket-path

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -7,6 +7,14 @@ pub fn get_path() -> Fallible<String> {
     if let Ok(sockpath) = env::var("I3SOCK") {
         return Ok(sockpath);
     }
+    let output = process::Command::new("i3")
+        .arg("--get-socketpath")
+        .output()?;
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout)
+            .trim_end_matches('\n')
+            .to_owned());
+    }
     if let Ok(sockpath) = env::var("SWAYSOCK") {
         return Ok(sockpath);
     }


### PR DESCRIPTION
Fixes https://github.com/greshake/i3status-rust/issues/705 and https://github.com/greshake/i3status-rust/pull/667#issuecomment-631238476

Note: I have not tested this myself but I don't believe there are any problems with the logic here.