### PR TITLE
Add nodes->max_render_time

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -219,6 +219,7 @@ pub struct Node {
     pub window_properties: Option<WindowProperties>,
     #[serde(default)]
     pub marks: Vec<String>,
+    pub max_render_time: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
See https://github.com/swaywm/sway/commit/bd9a53f1a3e7dba247aab0a4e4268724acc12c38

EDIT: This gives me `Error: Error("invalid type: integer `0`, expected a string", line: 1, column: 698)`, probably because max_render_time returns either a string `off` or an integer and I thought I could get away with just using String. I'll revisit this unless you have a quick fix.