### PR TITLE
fix: X11 window properties should be optional

### DIFF
--- a/src/reply.rs
+++ b/src/reply.rs
@@ -153,10 +153,12 @@ pub struct Rect {
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct WindowProperties {
     pub title: Option<String>,
-    pub instance: String,
-    pub class: String,
+    pub instance: Option<String>,
+    pub class: Option<String>,
     pub window_role: Option<String>,
-    pub transient_for: Option<String>,
+    // only this field is required, and it may be `null` so we need to handle it
+    #[serde(deserialize_with = "default_on_null")]
+    pub transient_for: String,
 }
 
 #[derive(Debug, PartialEq, Deserialize)]


### PR DESCRIPTION
See https://github.com/swaywm/sway/commit/03ca8596d6bcec0a83567d9b51a71ccc7db197e5

To test, run the hovered_window example and start `xev`.

Before this PR it will crash: ```Error: Error("missing field `instance`", line: 1, column: 784)```