### PR TITLE
Fix Error on deserializing Event WorkspaceEvent

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -14,7 +14,7 @@ pub struct Workspace {
     pub num: i32,
     pub name: String,
     pub layout: String,
-    pub visible: Option<bool>, // Missing in WorkspaceEvent.current and WorkspaceEvent.old
+    pub visible: bool,
     pub focused: bool,
     pub urgent: bool,
     pub representation: Option<String>,
@@ -436,8 +436,8 @@ pub struct TickEvent {
 #[derive(Debug, Deserialize)]
 pub struct WorkspaceEvent {
     pub change: WorkspaceChange,
-    pub current: Option<Workspace>, //Only None if WorkspaceChange::Reload
-    pub old: Option<Workspace>,     //Only None if WorkspaceChange::Reload
+    pub current: Option<Node>, //Only None if WorkspaceChange::Reload
+    pub old: Option<Node>,     //Only None if WorkspaceChange::Reload
 }
 
 #[non_exhaustive]

--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -14,7 +14,7 @@ pub struct Workspace {
     pub num: i32,
     pub name: String,
     pub layout: String,
-    pub visible: Option<bool>, // Missing in WorkspaceEvent.current and WorkspaceEvent.current
+    pub visible: Option<bool>, // Missing in WorkspaceEvent.current and WorkspaceEvent.old
     pub focused: bool,
     pub urgent: bool,
     pub representation: Option<String>,

--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -14,7 +14,7 @@ pub struct Workspace {
     pub num: i32,
     pub name: String,
     pub layout: String,
-    pub visible: bool,
+    pub visible: Option<bool>, // Missing in WorkspaceEvent.current and WorkspaceEvent.current
     pub focused: bool,
     pub urgent: bool,
     pub representation: Option<String>,


### PR DESCRIPTION
Sway-ipc leaves out the `visible` key in the values `current` and `old` on `WorkspaceEvent`. I fixed that with making the `visible` key optional (maybe not the best fix).