### PR TITLE
Fix disabled outputs have no id

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -42,7 +42,7 @@ pub struct Mode {
 #[non_exhaustive]
 #[derive(Debug, Deserialize)]
 pub struct Output {
-    pub id: i64,
+    pub id: Option<i64>, // Sway doesn't give disabled outputs ids
     pub name: String,
     pub make: String,
     pub model: String,


### PR DESCRIPTION
Sway doesn't give disabled outputs ids, but the deserializer is expecting it,.