### PR TITLE
fix BindingEvent, that had always BindingEventOps: None

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -439,8 +439,7 @@ pub struct WindowEvent {
 #[derive(Debug, Deserialize)]
 pub struct BindingEvent {
     pub change: BindingChange,
-    #[serde(flatten)]
-    pub optional: Option<BindingEventOps>,
+    pub binding: BindingEventOps,
 }
 
 #[non_exhaustive]
@@ -450,7 +449,7 @@ pub struct BindingEventOps {
     #[serde(default)]
     pub event_state_mask: Vec<String>,
     pub input_code: u8,
-    pub symbol: String,
+    pub symbol: Option<String>,
     pub input_type: InputType,
 }
 


### PR DESCRIPTION
sway-ipc(7) actually defines `binding` as an separate object, so no need
to flatten here.

> Example Event:
```json
    {
         "change": "run",
         "binding": {
              "command": "workspace 2",
              "event_state_mask": [
                   "Mod4"
              ],
              "input_code": 0,
              "symbol": "2",
              "input_type": "keyboard"
         }
    }
```

I verified, that I can now receive something like this: `Binding(BindingEvent { change: Run, binding: BindingEventOps { command: "focus up", event_state_mask: ["Mod4"], input_code: 0, symbol: "g", input_type: Keyboard } })` on Sway `1.5`.

Also I read

```
       ├─────────────────┼───────────┼─────────────────────────────┤
       │     symbol      │  string   │ For keyboard bindsyms, this │
       │                 │           │ is the bindsym for the      │
       │                 │           │ binding. Otherwise, this    │
       │                 │           │ will be null                │
       ├─────────────────┼───────────┼─────────────────────────────┤
```

so I guess `symbol` should be an `Option`?