### PR TITLE
i3 coordinate compatibility

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -163,8 +163,8 @@ pub struct Seat {
 #[non_exhaustive]
 #[derive(Debug, PartialEq, Deserialize)]
 pub struct Rect {
-    pub x: i32,
-    pub y: i32,
+    pub x: u64,
+    pub y: u64,
     pub width: i32,
     pub height: i32,
 }


### PR DESCRIPTION
Changing type of Rect.x and Rect.y to u64.

For your consideration... I haven't tested this in sway but it fixed an issue I had with swayipc-rs (via i3-focus-last) in i3 v4.19.1.

In i3 the tree-node for containers with negative screen positions look like this.
```
...
  "rect": {
    "x": 4294966497,
    "y": 4294966788,
    "width": 800,
    "height": 510
  },
...
```