### PR TITLE
Fix panic when calling `get_workspace` on i3

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -22,11 +22,13 @@ pub struct Workspace {
     pub id: i64,
     pub num: i32,
     pub name: String,
+    #[serde(default)]
     pub layout: String,
     pub visible: bool,
     pub focused: bool,
     pub urgent: bool,
     pub representation: Option<String>,
+    #[serde(default)]
     pub orientation: String,
     pub rect: Rect,
     pub output: String,


### PR DESCRIPTION
On i3, the output of `swaymsg -t get_workspaces -r`
looks like this:
```
  {
    "id": 93873798666352,
    "num": 1,
    "name": "1:    ",
    "visible": true,
    "focused": true,
    "rect": {
      "x": 0,
      "y": 18,
      "width": 1920,
      "height": 1062
    },
    "output": "eDP-1",
    "urgent": false
  }
```

Attempting to call `get_workspaces` from this crate would panic with one
of the following messages:
```
SerdeJson(Error("missing field `layout`", line: 1, column: 152))
SerdeJson(Error("missing field `orientation`", line: 1, column: 152))
```

To remain compatible with i3, let serde default initialize either of
these values as they won't be present on i3.

This incompatibility was observed through workstyle as reported here:
https://github.com/pierrechevalier83/workstyle/issues/21

This commit has been tested locally and gets workstyle to work on i3
again without having to fallback to i3ipc-rs.