### PR TITLE
fix: don't crash when connecting and neither i3 nor sway is installed

### DIFF
--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -14,7 +14,7 @@ pub struct Connection(Async<UnixStream>);
 impl Connection {
     /// Creates a new async `Connection` to sway-ipc.
     pub async fn new() -> Fallible<Self> {
-        let socketpath = get_socketpath().await;
+        let socketpath = get_socketpath().await?;
         loop {
             let stream = Async::<UnixStream>::connect(socketpath.as_path()).await;
             if matches!(stream.as_ref().map_err(|e| e.kind()), Err(NotConnected)) {

--- a/blocking/src/connection.rs
+++ b/blocking/src/connection.rs
@@ -11,7 +11,7 @@ pub struct Connection(UnixStream);
 impl Connection {
     /// Creates a new `Connection` to sway-ipc.
     pub fn new() -> Fallible<Self> {
-        let socketpath = get_socketpath();
+        let socketpath = get_socketpath()?;
         let unix_stream = UnixStream::connect(socketpath)?;
         Ok(Self(unix_stream))
     }

--- a/blocking/src/socket.rs
+++ b/blocking/src/socket.rs
@@ -2,20 +2,15 @@ use std::env;
 use std::io::Read;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use swayipc_types::Fallible;
+use swayipc_types::{Error, Fallible};
 
-pub fn get_socketpath() -> PathBuf {
-    PathBuf::from(if let Ok(socketpath) = env::var("I3SOCK") {
-        socketpath
-    } else if let Ok(socketpath) = env::var("SWAYSOCK") {
-        socketpath
-    } else if let Ok(socketpath) = spawn("i3") {
-        socketpath
-    } else if let Ok(socketpath) = spawn("sway") {
-        socketpath
-    } else {
-        unreachable!()
-    })
+pub fn get_socketpath() -> Fallible<PathBuf> {
+    env::var("I3SOCK")
+        .or_else(|_| env::var("SWAYSOCK"))
+        .or_else(|_| spawn("i3"))
+        .or_else(|_| spawn("sway"))
+        .map_err(|_| Error::SocketNotFound)
+        .map(PathBuf::from)
 }
 
 fn spawn(wm: &str) -> Fallible<String> {

--- a/types/src/error/mod.rs
+++ b/types/src/error/mod.rs
@@ -25,4 +25,6 @@ pub enum Error {
     CommandFailed(String),
     #[error("command could not be parsed '{0}'")]
     CommandParse(String),
+    #[error("could not find the socket for neither i3 nor sway")]
+    SocketNotFound,
 }


### PR DESCRIPTION
I maintain a project that uses swayipc to communicate to the window manager.

Recently, I added support for hyprland and I got [a report](https://github.com/pierrechevalier83/workstyle/issues/49) that my executable was crashing.
The crash was originating from [a call to `Connection::new()`](https://github.com/pierrechevalier83/workstyle/blob/b85006e6af8e45fc36d613ac92b51699646a4de8/src/window_manager.rs#L263), and the user confirmed that they didn't have Sway or I3 installed on their machine.

I had assumed that this call would err if it couldn't connect to the window manager (which it does as long as i3 or sway is installed), since it returned a `Result`, so I used it to decide which window manager to connect to: try sway or i3 first and if that fails, try hyprland.

Now I've read the code here, I could fix it on my side by basically re-implementing the logic inside `get_socketpath` in my crate, but I'd rather swayipc behaved as I had originally thought it would if you're OK with the change.