### PR TITLE
Add Node::iter

### DIFF
--- a/types/src/utils/node.rs
+++ b/types/src/utils/node.rs
@@ -104,7 +104,7 @@ impl Node {
         None
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a Node> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = &Node> {
         struct NodeIterator<'a> {
             queue: Vec<&'a Node>,
         }
@@ -123,7 +123,7 @@ impl Node {
             }
         }
 
-        NodeIterator { queue: vec![&self] }
+        NodeIterator { queue: vec![self] }
     }
 }
 

--- a/types/src/utils/node.rs
+++ b/types/src/utils/node.rs
@@ -116,9 +116,7 @@ impl Node {
                 match self.queue.pop() {
                     None => None,
                     Some(result) => {
-                        for node in result.nodes.iter() {
-                            self.queue.push(node);
-                        }
+                        self.queue.extend(result.nodes.iter());
                         Some(result)
                     }
                 }

--- a/types/src/utils/node.rs
+++ b/types/src/utils/node.rs
@@ -104,26 +104,26 @@ impl Node {
         None
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &Node> {
-        struct NodeIterator<'a> {
-            queue: Vec<&'a Node>,
-        }
+    pub fn iter(&self) -> NodeIterator<'_> {
+        NodeIterator { queue: vec![self] }
+    }
+}
 
-        impl<'a> Iterator for NodeIterator<'a> {
-            type Item = &'a Node;
+pub struct NodeIterator<'a> {
+    queue: Vec<&'a Node>,
+}
 
-            fn next(&mut self) -> Option<&'a Node> {
-                match self.queue.pop() {
-                    None => None,
-                    Some(result) => {
-                        self.queue.extend(result.nodes.iter());
-                        Some(result)
-                    }
-                }
+impl<'a> Iterator for NodeIterator<'a> {
+    type Item = &'a Node;
+
+    fn next(&mut self) -> Option<&'a Node> {
+        match self.queue.pop() {
+            None => None,
+            Some(result) => {
+                self.queue.extend(result.nodes.iter());
+                Some(result)
             }
         }
-
-        NodeIterator { queue: vec![self] }
     }
 }
 

--- a/types/src/utils/node.rs
+++ b/types/src/utils/node.rs
@@ -103,4 +103,132 @@ impl Node {
         }
         None
     }
+
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &'a Node> + 'a {
+        struct NodeIterator<'a> {
+            queue: Vec<&'a Node>,
+        }
+
+        impl<'a> Iterator for NodeIterator<'a> {
+            type Item = &'a Node;
+
+            fn next(&mut self) -> Option<&'a Node> {
+                match self.queue.pop() {
+                    None => None,
+                    Some(result) => {
+                        for node in result.nodes.iter() {
+                            self.queue.push(node);
+                        }
+                        Some(result)
+                    }
+                }
+            }
+        }
+
+        NodeIterator { queue: vec![&self] }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NodeBorder;
+    use crate::NodeLayout;
+    use crate::NodeType;
+    use crate::Rect;
+
+    fn rect() -> Rect {
+        Rect {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+        }
+    }
+
+    fn mk_node(name: Option<String>, node_type: NodeType, nodes: Vec<Node>) -> Node {
+        Node {
+            id: 1,
+            name,
+            node_type,
+            border: NodeBorder::Normal,
+            current_border_width: 0,
+            layout: NodeLayout::Tabbed,
+            percent: None,
+            rect: rect(),
+            window_rect: rect(),
+            deco_rect: rect(),
+            geometry: rect(),
+            urgent: false,
+            focused: false,
+            focus: Vec::new(),
+            nodes,
+            floating_nodes: Vec::new(),
+            sticky: false,
+            representation: None,
+            fullscreen_mode: None,
+            app_id: None,
+            pid: None,
+            window: None,
+            num: None,
+            window_properties: None,
+            marks: Vec::new(),
+            inhibit_idle: None,
+            idle_inhibitors: None,
+            shell: None,
+            visible: None,
+            output: None,
+        }
+    }
+
+    #[test]
+    fn returns_the_given_root_node_first() {
+        let root = mk_node(Some(String::from("root")), NodeType::Root, vec![]);
+        let mut iterator = root.iter();
+        assert_eq!(iterator.next().unwrap().name, Some("root".to_string()));
+    }
+
+    #[test]
+    fn returns_children_of_the_given_node() {
+        let root = mk_node(
+            Some("root".to_string()),
+            NodeType::Root,
+            vec![mk_node(Some("child".to_string()), NodeType::Con, vec![])],
+        );
+        let mut iterator = root.iter();
+        iterator.next();
+        assert_eq!(iterator.next().unwrap().name, Some("child".to_string()));
+    }
+
+    #[test]
+    fn returns_transitive_children_of_the_given_node() {
+        let root = mk_node(
+            Some("root".to_string()),
+            NodeType::Root,
+            vec![mk_node(
+                Some("child".to_string()),
+                NodeType::Con,
+                vec![mk_node(
+                    Some("grandchild".to_string()),
+                    NodeType::Con,
+                    vec![],
+                )],
+            )],
+        );
+        let mut iterator = root.iter();
+        iterator.next();
+        iterator.next();
+        assert_eq!(
+            iterator.next().unwrap().name,
+            Some("grandchild".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_at_the_end() {
+        let root = mk_node(Some("root".to_string()), NodeType::Root, vec![]);
+        let mut iterator = root.iter();
+        iterator.next();
+        assert_eq!(iterator.next(), None);
+    }
 }


### PR DESCRIPTION
This adds `Node::iter` that allows to iterate through all nodes breadth-first.

Please, let me know if you want me to make any changes to the code!