### PR TITLE
fix: bring back missing field of WindowProperties

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -249,6 +249,7 @@ pub struct WindowProperties {
     pub instance: Option<String>,
     pub class: Option<String>,
     pub window_role: Option<String>,
+    pub window_type: Option<String>,
     pub transient_for: Option<i32>,
 }
 


### PR DESCRIPTION
```rust
// source file: types/src/reply.rs
pub struct Node {
    /// ...
    /// (Only xwayland views) An object containing the title, class, instance,
    /// window_role, window_type, and transient_for for the view.
    pub window_properties: Option<WindowProperties>,
    /// ...
```
`WindowProperties` should have 6 fields: `title`, `class`, `instance`, `window_role`, `window_type`, and `transient_for`. However, in the definition of the struct `WindowProperties`, the field `window_type` is missing. This PR brings it back.