### PR TITLE
feat: add Event::event_type

### DIFF
--- a/types/src/utils/event.rs
+++ b/types/src/utils/event.rs
@@ -1,0 +1,18 @@
+use crate::{Event, EventType};
+
+impl Event {
+    pub fn event_type(&self) -> EventType {
+        match self {
+            Event::Workspace(_) => EventType::Workspace,
+            Event::Mode(_) => EventType::Mode,
+            Event::Window(_) => EventType::Window,
+            Event::BarConfigUpdate(_) => EventType::BarConfigUpdate,
+            Event::Binding(_) => EventType::Binding,
+            Event::Shutdown(_) => EventType::Shutdown,
+            Event::Tick(_) => EventType::Tick,
+            Event::BarStateUpdate(_) => EventType::BarStateUpdate,
+            Event::Input(_) => EventType::Input,
+            Event::Output(_) => EventType::Output,
+        }
+    }
+}

--- a/types/src/utils/mod.rs
+++ b/types/src/utils/mod.rs
@@ -1,1 +1,2 @@
+mod event;
 mod node;


### PR DESCRIPTION
Need it for registering events listeners dynamic, and is not possible to maintain this code downstream due to `non_exhaustive`.