### PR TITLE
Add i3 "changed" scratchpad state

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -328,8 +328,9 @@ pub enum Floating {
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ScratchpadState {
-    Fresh,
     None,
+    Fresh,
+    Changed,
 }
 
 #[non_exhaustive]


### PR DESCRIPTION
i3 has another possible scratchpad state that is missing in this repo's enum:

https://github.com/i3/i3/blob/4661e74b5ebe8727d1b0f8c29b1697f1f42daf70/include/data.h#L796

To be honest I am not entirely sure why it is important but I've managed to stumble on it when running i3 and it caused serialization errors.