### PR TITLE
Allow empty field `status_command`

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -486,7 +486,7 @@ pub struct BarConfig {
     /// The bar's position.  It can currently either be bottom or top.
     pub position: Position,
     /// The command which should be run to generate the status line.
-    pub status_command: String,
+    pub status_command: Option<String>,
     /// The font to use for the text on the bar.
     pub font: String,
     /// Whether to display the workspace buttons on the bar.


### PR DESCRIPTION
Do not require the field `status_command` to be a String type. Make it possible for deserialize to handle `null` value.

If the field `status_command` is not set in sway, the returned value in `null`. This can be seen with `swaymsg -t get_bar_config bar-0`. In case of `null` the test `get_bar_ids_and_one_config()` fails.

After making the field optional, serde does not crash and the test passes.