### PR TITLE
fix tap_drag_lock enum: add option enabled_sticky

### DIFF
--- a/types/src/reply.rs
+++ b/types/src/reply.rs
@@ -121,8 +121,8 @@ pub struct Libinput {
     pub tap_button_mapping: Option<ButtonMapping>,
     /// Whether tap-and-drag is enabled. It can be enabled or disabled.
     pub tap_drag: Option<EnabledOrDisabled>,
-    /// Whether drag-lock is enabled. It can be enabled or disabled.
-    pub tap_drag_lock: Option<EnabledOrDisabled>,
+    /// Whether drag-lock is enabled. It can be enabled, disabled or enabled_sticky.
+    pub tap_drag_lock: Option<DragLock>,
     /// The pointer-acceleration in use.
     pub accel_speed: Option<f64>,
     /// Whether natural scrolling is enabled. It can be enabled or disabled.
@@ -186,6 +186,14 @@ pub enum ScrollMethod {
 pub enum ButtonMapping {
     LMR,
     LRM,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DragLock {
+    Enabled,
+    Disabled,
+    EnabledSticky,
 }
 
 #[non_exhaustive]


### PR DESCRIPTION
Hi, I ran into a bug with the serde model for the `tap_drag_lock` field in the `Libinput` struct, used in `get_inputs` and `get_seats` commands.

Turns out that libinput supports the option `enabled_sticky` in addition to the usual `enabled` and `disabled`.

Here's the sway code that produces the value: https://github.com/swaywm/sway/blob/e3d9cc2aa5f1c298fd956b64e5e20f50aaac72fe/sway/ipc-json.c#L953

In my current setup, the output of `swaymsg -t get_inputs --raw` looks like this:

```
{
  ...,
    {
    "identifier": "1267:12693:ELAN0676:00_04F3:3195_Touchpad",
    "name": "ELAN0676:00 04F3:3195 Touchpad",
    "type": "touchpad",
    "scroll_factor": 1.0,
    "libinput": {
      "send_events": "enabled",
      "tap": "enabled",
      "tap_button_map": "lrm",
      "tap_drag": "enabled",
      "tap_drag_lock": "enabled_sticky",
      "accel_speed": 0.0,
      "accel_profile": "adaptive",
      "natural_scroll": "disabled",
      "left_handed": "disabled",
      "click_method": "button_areas",
      "clickfinger_button_map": "lrm",
      "middle_emulation": "disabled",
      "scroll_method": "two_finger",
      "dwt": "enabled",
      "dwtp": "enabled"
    },
    "vendor": 1267,
    "product": 12693
  },
  ...
}
```

So `cargo test` on  current master branch fails with:

```
---- tests::get_inputs stdout ----
thread 'tests::get_inputs' panicked at blocking/src/tests.rs:108:45:
called `Result::unwrap()` on an `Err` value: SerdeJson(Error("unknown variant `enabled_sticky`, expected `enabled` or `disabled`", line: 1, column: 3178))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::get_seats stdout ----
thread 'tests::get_seats' panicked at blocking/src/tests.rs:113:44:
called `Result::unwrap()` on an `Err` value: SerdeJson(Error("unknown variant `enabled_sticky`, expected `enabled` or `disabled`", line: 1, column: 3243))


failures:
    tests::get_inputs
    tests::get_seats
```

With the patch applied, the tests pass.